### PR TITLE
🧪🔐update registration tests with confirm_password

### DIFF
--- a/back-end/core/tests.py
+++ b/back-end/core/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/back-end/core/tests/test_jwt.py
+++ b/back-end/core/tests/test_jwt.py
@@ -31,6 +31,7 @@ def test_user_registration():
     userPayload = {
         "email": "user@example.com",
         "password": "test123",
+        "confirm_password": "test123",
         "username": "test123",
     }
 

--- a/back-end/core/tests/test_public_user_viewset.py
+++ b/back-end/core/tests/test_public_user_viewset.py
@@ -20,7 +20,8 @@ def test_create_user():
     payload = {
         "email": "test@mail.com",
         "username": "johhan",
-        "password": "supersecret"
+        "password": "supersecret",
+        "confirm_password": "supersecret",
     }
 
     response = client.post(url,payload,format="json")
@@ -31,7 +32,7 @@ def test_create_user():
     assert "password" not in data #Password should not be exposed
 
 @pytest.mark.django_db
-def test_get_user(create_user):
+def test_get_user(create_user,get_token):
     """
     Test that retrieving users from the API works correctly.
 
@@ -45,6 +46,7 @@ def test_get_user(create_user):
 
     url = reverse("user-list")
 
+    client.credentials(HTTP_AUTHORIZATION=f'Bearer {get_token}')
     response = client.get(url,format="json")
 
     assert response.status_code == 200

--- a/back-end/core/tests/test_user_serializers.py
+++ b/back-end/core/tests/test_user_serializers.py
@@ -22,7 +22,8 @@ def test_user_serializer_create(test_image):
         "email": "test@mail.com",
         "username": "John Doe",
         "profile_picture": test_image,
-        "password": "supersecret"
+        "password": "supersecret",
+        "confirm_password":"supersecret"
     }
 
     serializer = PublicUserSerializer(data=data)


### PR DESCRIPTION
This PR enhances our test suite by improving authentication flow and aligning registration tests with the new serializer validation.

- 🆕 Added a reusable JWT token fixture (get_token) for authenticated API calls.

- 🔐 Updated user registration tests to include the new confirm_password field.

- ✅ Ensured tests validate both password hashing and secure authentication.

This strengthens test coverage and makes future API tests cleaner and more reliable.