### PR TITLE
✨ Add DeckViewSet with JWT auth + unit tests

### DIFF
--- a/back-end/core/tests/test_deck_viewset.py
+++ b/back-end/core/tests/test_deck_viewset.py
@@ -1,0 +1,47 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from core.models import Deck, User
+
+@pytest.mark.django_db
+def test_authenticated_user_can_create_deck(create_user, get_token):
+    """
+    Authenticated users should be able to create a deck.
+    """
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {get_token}")
+
+    url = reverse("deck-list")
+    payload = {
+        "title": "Networking Deck",
+        "description": "OSI Layers",
+        "color": "#9333EA"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 201  # Created
+    data = response.json()
+
+    deck = Deck.objects.get(id=data["id"])
+    assert deck.user == create_user
+    assert deck.title == "Networking Deck"
+
+@pytest.mark.django_db
+def test_user_only_sees_their_own_decks(get_token):
+    """
+    A user should only see their own decks (if get_queryset filters by request.user).
+    """
+    other_user = User.objects.create_user(
+        email="other@mail.com", username="other", password="secret"
+    )
+    Deck.objects.create(user=other_user, title="Other Deck", description="Not yours")
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {get_token}")
+
+    url = reverse("deck-list")
+    response = client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert all(deck["title"] != "Other Deck" for deck in data)

--- a/back-end/core/urls.py
+++ b/back-end/core/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path,include
 from rest_framework.routers import DefaultRouter
-from .views import PublicUserViewSet
+from .views import PublicUserViewSet,DeckViewSet
 
 router = DefaultRouter()
 router.register(r'users',PublicUserViewSet,basename='user')
+router.register(r'decks',DeckViewSet,basename="deck")
 
 urlpatterns = [
     path('',include(router.urls))

--- a/back-end/core/views.py
+++ b/back-end/core/views.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
-from .models import User
-from .serializer import PublicUserSerializer,CustomTokenObtainPairSerializer
+from .models import User,Deck
+from .serializer import PublicUserSerializer,CustomTokenObtainPairSerializer,DeckSerializer
 
 from rest_framework_simplejwt.views import TokenObtainPairView
 from rest_framework.permissions import IsAuthenticated, AllowAny
@@ -18,3 +18,16 @@ class PublicUserViewSet(viewsets.ModelViewSet):
     
 class CustomTokenObtainPairView(TokenObtainPairView):
     serializer_class = CustomTokenObtainPairSerializer
+
+class DeckViewSet(viewsets.ModelViewSet):
+    queryset = Deck.objects.all()
+    serializer_class = DeckSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        # Only return decks that belong to the authenticated user
+        return Deck.objects.filter(user=self.request.user)
+
+    def perform_create(self, serializer):
+        # Automatically set the deck's user to the logged-in user
+        serializer.save(user=self.request.user)


### PR DESCRIPTION
This PR introduces the DeckViewSet to handle CRUD operations on the Deck model, secured with JWT authentication.
Key updates:

- ➕ Added DeckViewSet with get_queryset filtering by request.user

- 🔒 Secured endpoints with IsAuthenticated permission

- 🛠️ Implemented perform_create to automatically assign the deck owner

🧪 Added unit tests to validate:

- ✅ Authenticated user can create a deck

- 🚫 Users cannot access decks belonging to others

This ensures each user only manages their own decks while keeping endpoints protected.