### PR TITLE
🗑️✨ Feature: Delete Deck Endpoint + Auto Refresh in Main Panel

### DIFF
--- a/front-end/src/components/DeckComponents/DeckCard.tsx
+++ b/front-end/src/components/DeckComponents/DeckCard.tsx
@@ -4,9 +4,10 @@ interface DeckCardProps {
   id:number;
   title: string;
   color: string;
+  onDelete?: () => void; 
 }
 
-const DeckCard: React.FC<DeckCardProps> = ({ id,title,color }) => {
+const DeckCard: React.FC<DeckCardProps> = ({ id,title,color,onDelete }) => {
   return (
     <div className="relative group w-65 h-55 rounded-xl shadow-lg overflow-hidden transform transition-transform duration-200 hover:scale-105 cursor-pointer">
       {/* Base background */}
@@ -24,7 +25,7 @@ const DeckCard: React.FC<DeckCardProps> = ({ id,title,color }) => {
       <div className="absolute top-3 right-3 hidden group-hover:block">
         <OptionsMenu
           deckId={id}
-          onDelete={() => console.log(`Deleting ${title}`)}
+          onDelete={onDelete}
         />
       </div>
     </div>

--- a/front-end/src/components/DeckComponents/MainPanel.tsx
+++ b/front-end/src/components/DeckComponents/MainPanel.tsx
@@ -22,6 +22,11 @@ const MainPanel = () => {
     fetchDecks();
   }, []);
 
+  const handleDeleteDeck = (deckId: number) => {
+    setDecks((prev) => prev.filter((deck) => deck.id !== deckId));
+  };
+
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-black from-10% via-black via-40% to-purple-700 to-100%">
       <div className="p-6 flex flex-col items-center">
@@ -33,7 +38,7 @@ const MainPanel = () => {
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-16 gap-y-20">
               {decks.map((deck) => (
-                <DeckCard key={deck.id} id={deck.id} title={deck.title} color={deck.color}/>
+                <DeckCard key={deck.id} id={deck.id} title={deck.title} color={deck.color} onDelete={()=>handleDeleteDeck(deck.id)}/>
               ))}
             </div>
           )}

--- a/front-end/src/components/DeckComponents/OptionsMenu.tsx
+++ b/front-end/src/components/DeckComponents/OptionsMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import ThreeDotsIcon from "../../assets/Deck/tree-dots-option.svg";
+import { deleteDeck } from "../../services/deckService"
 
 interface OptionsMenuProps {
   deckId: number;
@@ -25,6 +26,21 @@ const OptionsMenu: React.FC<OptionsMenuProps> = ({ deckId, onDelete }) => {
     };
   }, []);
 
+  const handleDelete = async () => {
+    try {
+      await deleteDeck(deckId)
+      console.log("✅ Deck deleted successfully");
+
+      if (onDelete) {
+        onDelete(); //notify parent
+      }
+    } catch (error) {
+      console.error("Error deleting deck:", error);
+    } finally {
+      setOpen(false); // close the menu after action
+    }
+  };
+
   return (
     <div className="relative" ref={menuRef}>
       {/* 3 dots button */}
@@ -46,7 +62,7 @@ const OptionsMenu: React.FC<OptionsMenuProps> = ({ deckId, onDelete }) => {
               ✏️ Edit
             </li>
             <li
-              onClick={onDelete}
+              onClick={handleDelete}
               className="px-4 py-2 hover:bg-red-600 cursor-pointer"
             >
               🗑️ Delete

--- a/front-end/src/services/deckService.ts
+++ b/front-end/src/services/deckService.ts
@@ -6,3 +6,8 @@ export const getDecks = async (): Promise<Deck[]> => {
   const response = await api.get<Deck[]>("/decks/");
   return response.data;
 };
+
+
+export const deleteDeck = async (deckId: number): Promise<void> => {
+  await api.delete(`/decks/${deckId}/`);
+};


### PR DESCRIPTION
This PR adds full support for deleting decks directly from the OptionsMenu and ensures the UI updates automatically in the MainPanel after deletion:

- 🗑️ Delete API Call: Integrated deleteDeck(deckId) service to call backend endpoint.

- 🎛️ OptionsMenu: Added handleDelete logic to trigger deck removal.

- 🔄 MainPanel Refresh: After successful deletion, the parent state updates so the deck disappears instantly from the grid.

- 🖼️ DeckCard → OptionsMenu: Connected callback props to propagate delete events upwards.

- 🚀 UX Improvement: Smooth flow without page reloads.