### PR TITLE
📝✨ Add EditFlashCard workflow & fix DeckDetail navigation into OptionsMenu

### DIFF
--- a/front-end/src/components/DeckComponents/DeckCard.tsx
+++ b/front-end/src/components/DeckComponents/DeckCard.tsx
@@ -26,7 +26,7 @@ const DeckCard: React.FC<DeckCardProps> = ({
 
   const handleCardClick = () => {
     if (!clickable) return;
-    navigate(to ?? `/decks/${id}`, {
+    navigate(to ?? `/decks/${id}/study`, {
       state: { color, title }, // 👈 pasamos props al detalle
     });
   };

--- a/front-end/src/components/DeckComponents/DeckDetail.tsx
+++ b/front-end/src/components/DeckComponents/DeckDetail.tsx
@@ -3,35 +3,41 @@ import { useParams, useLocation } from "react-router-dom";
 import { getFlashcardsByDeck } from "../../services/flashcardService";
 import type { Flashcard as FlashcardType } from "../../types/flashcard";
 import Flashcard from "../../components/FlashCardComponents/Flashcard";
+import EditFlashCard from "../../components/FlashCardComponents/EditFlashCard";
 
 const DeckDetail = () => {
   const { deckId } = useParams<{ deckId: string }>();
   const [flashcards, setFlashcards] = useState<FlashcardType[]>([]);
   const [loading, setLoading] = useState(true);
-  const [visibleCount, setVisibleCount] = useState(12); // 👈 initial batch
+  const [visibleCount, setVisibleCount] = useState(12);
   const observerRef = useRef<HTMLDivElement | null>(null);
 
-  // 👇 color y título pasados desde DeckCard (MainPanel)
+  // modal states
+  const [selectedFlashcard, setSelectedFlashcard] = useState<FlashcardType | null>(null);
+  const [showEdit, setShowEdit] = useState(false);
+
+  // color y título desde DeckCard
   const location = useLocation();
   const state = location.state as { color?: string; title?: string };
 
-  useEffect(() => {
-    const fetchFlashcards = async () => {
-      try {
-        if (!deckId) return;
-        const data = await getFlashcardsByDeck(Number(deckId));
-        setFlashcards(data);
-      } catch (error) {
-        console.error("❌ Error fetching flashcards:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
+  // fetch flashcards
+  const fetchFlashcards = async () => {
+    try {
+      if (!deckId) return;
+      const data = await getFlashcardsByDeck(Number(deckId));
+      setFlashcards(data);
+    } catch (error) {
+      console.error("❌ Error fetching flashcards:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
+  useEffect(() => {
     fetchFlashcards();
   }, [deckId]);
 
-  // IntersectionObserver para infinite scroll
+  // infinite scroll
   useEffect(() => {
     if (!observerRef.current) return;
 
@@ -64,22 +70,48 @@ const DeckDetail = () => {
       ) : (
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {flashcards.slice(0, visibleCount).map((card,idx) => (
-              <Flashcard
+            {flashcards.slice(0, visibleCount).map((card, idx) => (
+              <div
                 key={card.id}
-                card={card}
-                index={idx}
-              />
+                onClick={() => {
+                  setSelectedFlashcard(card);
+                  setShowEdit(true);
+                }}
+                className="cursor-pointer"
+              >
+                <Flashcard card={card} index={idx} />
+              </div>
             ))}
           </div>
 
-          {/* Sentinel para el observer */}
+          {/* Sentinel */}
           {visibleCount < flashcards.length && (
             <div ref={observerRef} className="h-10 flex justify-center items-center">
               <p className="text-gray-300">Loading more...</p>
             </div>
           )}
         </>
+      )}
+
+      {/* Edit modal */}
+      {showEdit && selectedFlashcard && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <div className="relative flex justify-center bg-[#1E1E1E]/25 backdrop-blur-lg border border-white/10 p-7 rounded-xl shadow-xl w-220 h-125">
+            <EditFlashCard
+              flashcard={selectedFlashcard}
+              onUpdated={() => {
+                setShowEdit(false);
+                fetchFlashcards();
+              }}
+            />
+            <button
+              onClick={() => setShowEdit(false)}
+              className="absolute top-3 right-3 text-gray-300 hover:text-purple-400"
+            >
+              ✖
+            </button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/front-end/src/components/DeckComponents/OptionsMenu.tsx
+++ b/front-end/src/components/DeckComponents/OptionsMenu.tsx
@@ -33,7 +33,7 @@ const OptionsMenu: React.FC<OptionsMenuProps> = ({ deckId, onDelete, onEdit }) =
       console.log("✅ Deck deleted successfully");
 
       if (onDelete) {
-        onDelete(); //notify parent
+        onDelete(); // notify parent
       }
     } catch (error) {
       console.error("Error deleting deck:", error);
@@ -49,6 +49,11 @@ const OptionsMenu: React.FC<OptionsMenuProps> = ({ deckId, onDelete, onEdit }) =
     setOpen(false);
   };
 
+  const handleDetails = () => {
+    navigate(`/decks/${deckId}`);
+    setOpen(false);
+  };
+
   return (
     <div className="relative" ref={menuRef}>
       {/* 3 dots button */}
@@ -61,8 +66,14 @@ const OptionsMenu: React.FC<OptionsMenuProps> = ({ deckId, onDelete, onEdit }) =
 
       {/* Dropdown */}
       {open && (
-        <div className="absolute right-0 mt-2 w-32 bg-[#1F1F2E] rounded-md shadow-lg ring-1 ring-black/10 z-10">
+        <div className="absolute right-0 mt-2 w-36 bg-[#1F1F2E] rounded-md shadow-lg ring-1 ring-black/10 z-10">
           <ul className="py-1 text-sm text-gray-200">
+            <li
+              onClick={handleDetails}
+              className="px-4 py-2 hover:bg-blue-600 cursor-pointer"
+            >
+              📂 Details
+            </li>
             <li
               onClick={handleEdit}
               className="px-4 py-2 hover:bg-purple-600 cursor-pointer"

--- a/front-end/src/components/FlashCardComponents/EditFlashCard.tsx
+++ b/front-end/src/components/FlashCardComponents/EditFlashCard.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from "react";
+import type { Flashcard } from "../../types/flashcard";
+import { updateFlashcard } from "../../services/flashcardService";
+
+interface EditFlashCardProps {
+  flashcard: Flashcard;
+  onUpdated?: () => void;
+}
+
+const EditFlashCard: React.FC<EditFlashCardProps> = ({ flashcard, onUpdated }) => {
+  const [front, setFront] = useState(flashcard.front);
+  const [back, setBack] = useState(flashcard.back);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async () => {
+    if (!front.trim() || !back.trim()) {
+      setError("⚠️ Please fill out all fields.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError("");
+
+      await updateFlashcard(flashcard.id, {
+        front,
+        back,
+        deck: flashcard.deck, // mantiene el deck
+      });
+
+      console.log("✅ Flashcard updated");
+
+      if (onUpdated) onUpdated();
+    } catch (err) {
+      console.error("❌ Error updating flashcard:", err);
+      setError("Failed to update flashcard. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSubmit();
+      }}
+      className="w-200 h-full bg-gradient-to-b from-[#1E1E2F] to-[#111111] p-6 rounded-2xl text-white shadow-[0_0_20px_rgba(138,43,226,0.25)]"
+    >
+      <h2 className="text-2xl font-semibold mb-6">Edit Card</h2>
+
+      {/* Front */}
+      <label className="block mb-2 text-sm font-medium">Front</label>
+      <textarea
+        value={front}
+        onChange={(e) => setFront(e.target.value)}
+        className="w-full p-3 mb-4 rounded-lg bg-[#1F1F2E] text-white resize-none overflow-hidden focus:outline-none focus:ring-2 focus:ring-purple-500"
+        rows={1}
+        placeholder="Front"
+      />
+
+      {/* Back */}
+      <label className="block mb-2 text-sm font-medium">Back</label>
+      <textarea
+        value={back}
+        onChange={(e) => setBack(e.target.value)}
+        className="w-full p-3 mb-6 rounded-lg bg-[#1F1F2E] text-white resize-none overflow-hidden focus:outline-none focus:ring-2 focus:ring-purple-500"
+        rows={1}
+        placeholder="Back"
+      />
+
+      {/* Error */}
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+
+      {/* Button */}
+      <div className="flex justify-end mt-6">
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-6 py-3 rounded-md font-semibold text-white 
+                     bg-gradient-to-b from-[#A855F7] to-[#7C3AED] 
+                     shadow-[0_0_20px_rgba(138,43,226,0.25)]
+                     hover:opacity-90 hover:scale-105 transition-transform 
+                     disabled:opacity-50"
+        >
+          {loading ? "Saving..." : "Save Changes"}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default EditFlashCard;

--- a/front-end/src/services/flashcardService.ts
+++ b/front-end/src/services/flashcardService.ts
@@ -12,3 +12,8 @@ export const createFlashcard = async (payload: FlashcardCreate): Promise<Flashca
   const response = await api.post<Flashcard>("/flashcards/", payload);
   return response.data;
 };
+
+export const updateFlashcard = async (id: number, data: Partial<Flashcard>): Promise<Flashcard> => {
+  const response = await api.put<Flashcard>(`/flashcards/${id}/`, data);
+  return response.data;
+};


### PR DESCRIPTION
## Overview
This PR introduces the new EditFlashCard workflow and includes a fix in the DeckDetail navigation logic by delegating the "Details" route into the OptionsMenu component.

## Changes
- 📝 Added new EditFlashCard component with same UI/UX style as CreateFlashCard.
- 🎨 Aligned styles to match CreateFlashCard (gradient background, purple glow, focus ring).
- 💾 Implemented PUT request workflow to update flashcards.
- 📂 Clicking a flashcard in DeckDetail now opens EditFlashCard modal.
- 🔧 Fixed DeckDetail navigation by moving "Details" route into OptionsMenu 3-dots menu.

## Impact
- Improves consistency between create and edit flashcard flows.
- Centralizes navigation logic in OptionsMenu instead of DeckCard.
- Enhances overall UX by allowing inline editing of flashcards directly from DeckDetail.
