### PR TITLE
✨ Add Deck Study workflow with study session & spaced repetition

### DIFF
--- a/back-end/core/serializer.py
+++ b/back-end/core/serializer.py
@@ -129,3 +129,6 @@ class FlashCardSerializer(serializers.ModelSerializer):
             raise PermissionDenied("You cannot add flashcards to this deck.")
 
         return super().create(validated_data)
+    
+class FlashcardReviewSerializer(serializers.Serializer):
+    answer = serializers.ChoiceField(choices=["again", "good", "easy"])

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -3,6 +3,8 @@ import Login from "./components/AuthComponents/Login";
 import Registration from "./components/AuthComponents/Registration";
 import MainPanel from "./components/DeckComponents/MainPanel"
 import DeckDetail from "./components/DeckComponents/DeckDetail";
+import DeckStudy from "./components/DeckComponents/DeckStudy";
+import StudySession from "./components/StudySessionComponents/StudySession";
 
 function App() {
   return (
@@ -18,6 +20,10 @@ function App() {
         <Route path="/mainpanel" element={<MainPanel/>} />
 
         <Route path="/decks/:deckId" element={<DeckDetail/>} />
+
+        <Route path="/decks/:deckId/study" element={<DeckStudy/>} />
+
+        <Route path="/decks/:deckId/session" element={<StudySession />} />
       </Routes>
     </Router>
   );

--- a/front-end/src/components/DeckComponents/DeckStudy.tsx
+++ b/front-end/src/components/DeckComponents/DeckStudy.tsx
@@ -1,0 +1,114 @@
+import { useLocation, useParams, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import type { Flashcard } from "../../types/flashcard";
+import { getFlashcardsByDeck } from "../../services/flashcardService";
+
+const DeckStudy = () => {
+  const { deckId } = useParams<{ deckId: string }>();
+  const location = useLocation();
+
+  // 👇 includes optional congratulation message
+  const state = (location.state as { color?: string; title?: string; message?: string }) || {};
+
+  const [flashcards, setFlashcards] = useState<Flashcard[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [newCards, setNewCards] = useState<Flashcard[]>([]);
+  const [dueCards, setDueCards] = useState<Flashcard[]>([]);
+  const [reviewCards, setReviewCards] = useState<Flashcard[]>([]);
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchCards = async () => {
+      try {
+        if (!deckId) return;
+        const data = await getFlashcardsByDeck(Number(deckId));
+        setFlashcards(data);
+
+        const now = new Date();
+
+        setNewCards(data.filter((c) => c.status === "new"));
+        setDueCards(
+          data.filter((c) => c.due_date && new Date(c.due_date) <= now && c.status !== "new")
+        );
+        setReviewCards(
+          data.filter(
+            (c) => c.status === "review" && (!c.due_date || new Date(c.due_date) > now)
+          )
+        );
+      } catch (error) {
+        console.error("❌ Error fetching flashcards:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCards();
+  }, [deckId]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-white">
+        <p>Loading study data...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-black via-black to-purple-700 text-white p-8">
+      {/* 🎉 Success banner */}
+      {state.message && (
+        <div className="mb-6 p-4 rounded-lg bg-green-600 text-white font-semibold shadow-lg text-center">
+          {state.message}
+        </div>
+      )}
+
+      {/* Title with fallback */}
+      <h2 className="text-4xl font-bold mb-6">
+        {state.title ?? "Deck"} Study
+      </h2>
+
+      {/* Stats */}
+      <div
+        className="p-6 rounded-2xl shadow-xl mb-10"
+        style={{ backgroundColor: state.color ?? "#1E1E1E" }}
+      >
+        <h3 className="text-3xl font-bold mb-6">Today's Cards</h3>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+          {/* New cards */}
+          <div className="bg-black/40 p-6 rounded-xl text-center shadow-lg">
+            <p className="text-4xl font-bold text-blue-400">{newCards.length}</p>
+            <p className="text-gray-300 mt-2 font-bold">New</p>
+          </div>
+
+          {/* Due cards */}
+          <div className="bg-black/40 p-6 rounded-xl text-center shadow-lg">
+            <p className="text-4xl font-bold text-green-400">{dueCards.length}</p>
+            <p className="text-gray-300 mt-2 font-bold">Due</p>
+          </div>
+
+          {/* Review cards */}
+          <div className="bg-black/40 p-6 rounded-xl text-center shadow-lg">
+            <p className="text-4xl font-bold text-yellow-400">{reviewCards.length}</p>
+            <p className="text-gray-300 mt-2 font-bold">Review</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Start button */}
+      <div className="flex justify-center">
+        <button
+          className="px-12 py-5 rounded-2xl text-2xl font-bold bg-gradient-to-r from-purple-600 to-purple-800 
+                     hover:opacity-90 hover:scale-105 transition-transform shadow-lg cursor-pointer"
+          onClick={() => navigate(`/decks/${deckId}/session`)}
+        >
+          ▶️ Start Study
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DeckStudy;

--- a/front-end/src/components/StudySessionComponents/StudySession.tsx
+++ b/front-end/src/components/StudySessionComponents/StudySession.tsx
@@ -1,0 +1,122 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import type { Flashcard } from "../../types/flashcard";
+import {
+  getFlashcardsByDeck,
+  reviewFlashcard,
+  getStudyCards,
+} from "../../services/flashcardService";
+
+const StudySession = () => {
+  const { deckId } = useParams<{ deckId: string }>();
+  const navigate = useNavigate();
+
+  const [flashcards, setFlashcards] = useState<Flashcard[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [showBack, setShowBack] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCards = async () => {
+      try {
+        const data = await getStudyCards(deckId); // 👈 ahora solo carga las nuevas + due
+        setFlashcards(data);
+      } catch (error) {
+        console.error("❌ Error fetching study cards:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCards();
+  }, [deckId]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-white">
+        <p>Loading study session...</p>
+      </div>
+    );
+  }
+
+  if (flashcards.length === 0) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-white">
+        <p>No flashcards available in this deck 📭</p>
+      </div>
+    );
+  }
+
+  const currentCard = flashcards[currentIndex];
+
+  const handleAnswer = async (type: "again" | "good" | "easy") => {
+    try {
+      await reviewFlashcard(currentCard.id, type);
+      setShowBack(false);
+
+      if (currentIndex < flashcards.length - 1) {
+        setCurrentIndex((prev) => prev + 1);
+      } else {
+        // Redirect back to DeckStudy with success message
+        navigate(`/decks/${deckId}/study`, {
+          state: {
+            message:
+              "🎉 Congratulations! You have completed the study session.",
+          },
+        });
+      }
+    } catch (error) {
+      console.error("❌ Error reviewing flashcard:", error);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-black via-black to-purple-700 flex flex-col items-center justify-center text-white p-6">
+      <h2 className="text-3xl font-bold mb-8">
+        Card {currentIndex + 1} of {flashcards.length}
+      </h2>
+
+      {/* Flashcard container */}
+      <div className="w-full max-w-md h-64 flex items-center justify-center rounded-2xl shadow-xl bg-[#1E1E2F] p-6 mb-8 text-center">
+        {!showBack ? (
+          <p className="text-xl font-semibold">{currentCard.front}</p>
+        ) : (
+          <p className="text-xl">{currentCard.back}</p>
+        )}
+      </div>
+
+      {/* Buttons */}
+      {!showBack ? (
+        <button
+          onClick={() => setShowBack(true)}
+          className="px-8 py-3 rounded-xl text-lg font-bold bg-purple-600 hover:bg-purple-500 shadow-lg transition"
+        >
+          Show Answer
+        </button>
+      ) : (
+        <div className="flex gap-4">
+          <button
+            onClick={() => handleAnswer("again")}
+            className="px-6 py-3 rounded-xl bg-red-600 hover:bg-red-500 font-bold shadow-lg"
+          >
+            🔁 Again
+          </button>
+          <button
+            onClick={() => handleAnswer("good")}
+            className="px-6 py-3 rounded-xl bg-yellow-500 hover:bg-yellow-400 font-bold shadow-lg text-black"
+          >
+            👍 Good
+          </button>
+          <button
+            onClick={() => handleAnswer("easy")}
+            className="px-6 py-3 rounded-xl bg-green-600 hover:bg-green-500 font-bold shadow-lg"
+          >
+            💯 Easy
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StudySession;

--- a/front-end/src/services/flashcardService.ts
+++ b/front-end/src/services/flashcardService.ts
@@ -17,3 +17,20 @@ export const updateFlashcard = async (id: number, data: Partial<Flashcard>): Pro
   const response = await api.put<Flashcard>(`/flashcards/${id}/`, data);
   return response.data;
 };
+
+export const reviewFlashcard = async (
+  id: number,
+  answer: "again" | "good" | "easy"
+): Promise<Flashcard> => {
+  const response = await api.post<Flashcard>(`/flashcards/${id}/review/`, {
+    answer, // 👈 lo único que necesita el backend
+  });
+  return response.data;
+};
+
+// Fetch flashcards available for study (new + due)
+export const getStudyCards = async (deckId?: string): Promise<Flashcard[]> => {
+  const url = deckId ? `/flashcards/study/?deck=${deckId}` : "/flashcards/study/";
+  const response = await api.get<Flashcard[]>(url);
+  return response.data;
+};


### PR DESCRIPTION
This PR introduces the new Deck Study workflow, enabling users to practice flashcards with a study session and spaced repetition algorithm.

Key changes:
- Added backend `study_cards` endpoint to return only due and new flashcards (filtered by deck).
- Implemented `review` endpoint logic to update flashcard status, interval, ease factor, due date, streak, and lapses.
- Added `getStudyCards` service method in frontend to consume the new endpoint.
- Created `StudySession` component to handle study flow:
  - Displays flashcards one by one.
  - Allows user answers: Again 🔁, Good 👍, Easy 💯.
  - Updates flashcards using the review API.
  - Shows progress counter and handles flip front/back.
  - Redirects back to `DeckStudy` with a success message once session is completed.
- Updated `DeckStudy` to display congratulation messages returned from `StudySession`.

This completes the core study flow similar to Anki, with proper SRS scheduling logic.
